### PR TITLE
PlayStore 배포 시 난독화로 인한 실행 오류 수정

### DIFF
--- a/ThinkerBell/data/build.gradle.kts
+++ b/ThinkerBell/data/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/ThinkerBell/presentation/build.gradle.kts
+++ b/ThinkerBell/presentation/build.gradle.kts
@@ -50,7 +50,7 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## 🍀 Summary
<!-- 어떤 내용의 PR인가요? -->
1.2.0 버전에서 난독화로 인해 앱이 실행되지 않는 문제를 발견했습니다.
시간 상 임시로 비활성화 처리하였습니다.
<br>

## ☑️ Checklist
<!-- PR 요청 시 체크해주세요 -->
- [x] Base Branch
- [x] Assignees
- [x] Labels
- [x] Issue Number
- [x] Conflict Resolve
<br>

## 💡 Comment
<!-- 전달하고 싶은 내용이 있나요? -->
추후 프로가드 설정이 필요합니다.